### PR TITLE
Added functionality for going back to main screen from Join Team

### DIFF
--- a/ChromeExtension/Frontend/assets/js/popup.js
+++ b/ChromeExtension/Frontend/assets/js/popup.js
@@ -12,6 +12,13 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
+    let back_to_main_button_from_join = document.getElementById("back-to-main-screen-from-join");
+    if (back_to_main_button_from_join) {
+        back_to_main_button_from_join.addEventListener("click", function () {
+            window.location.href = "main-screen.html"; // Navigate back to main screen
+        });
+    }
+
     let create_team_button = document.getElementById("create-team-button");
     if (create_team_button) {
         create_team_button.addEventListener("click", function () {

--- a/ChromeExtension/Frontend/join-team-screen.html
+++ b/ChromeExtension/Frontend/join-team-screen.html
@@ -13,7 +13,7 @@
 
     <div id="join-team-screen" class="screen active">
 
-        <button id="back-to-main-screen" class="back-btn">←</button>
+        <button id="back-to-main-screen-from-join" class="back-btn">←</button>
 
         <h2>Got a <span class="highlight">team code</span>? Paste it here!</h2>
 
@@ -23,7 +23,7 @@
 
     </div>
 
-    <script src="assets/js/popup.js"></script>
+    <script type="module" src="assets/js/popup.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
In this pull request, you can now go back to the main screen by clicking on the back button from Join Team. I just used two separate IDs from the back button and set `type="module"` for the html.