### PR TITLE
Add code of conduct and routing to and from it

### DIFF
--- a/ChromeExtension/Frontend/assets/css/signup.css
+++ b/ChromeExtension/Frontend/assets/css/signup.css
@@ -41,6 +41,10 @@ input:focus {
     color: rgb(0, 0, 0);
 }
 
+a {
+    color: black;
+}
+
 
 .center-container {
     display: flex;
@@ -75,6 +79,12 @@ input:focus {
 
 .side-by-side {
     display: flex;
+    margin-right: 10px;
+}
+
+.list-class {
+    font-size: medium;
+    line-height: 25px;
 }
 
 #middle-box {

--- a/ChromeExtension/Frontend/code-of-conduct.html
+++ b/ChromeExtension/Frontend/code-of-conduct.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"> <!-- reactive resizing based on user's device -->
+    <title>create team screen</title>
+    <link rel="stylesheet" href="assets/css/signup.css">
+</head>
+
+<body>
+    <div class="side-space">
+        <br><br>
+        <h2>User Code of Conduct</h2>
+        <br>
+    </div>
+    <div class="list-class" id="code-of-conduct-rules">
+        <ol>
+            <p>
+                <li>
+                    Be appropriate while using the chat functionality.
+                    No cursing, harassing, or threatening others verbally.
+                </li>
+            </p>
+            <p>
+                <li>
+                    Be safe! Do not post personal information while using the chat functionality.
+                    This includes home address, social security number, and Leetcode password.
+                </li>
+            </p>
+            <p>
+                <li>
+                    No cheating! This includes receiving help from others, using generative AI,
+                    and copying and pasting code during Yeetbattles.
+                </li>
+            </p>
+            <p>
+                <li>
+                    Have fun. YEET!
+                </li>
+            </p>
+        </ol>
+    </div>
+    <div class="side-space">
+        <br><br>
+        <h2>Ownership of Content</h2>
+        <br>
+    </div>
+    <div class="list-class" id="ownership-content-rules">
+        <ol>
+            <p>
+                <li>
+                    All content on our extension, including text, images, code,
+                    and animation is owned by the Yeetcode team.
+                </li>
+            </p>
+            <p>
+                <li>
+                    The source code is publically available on Github with certain
+                    terms of use. Review them thoroughly and avoid commiting intellectual
+                    robbery:
+                    <a href="https://github.com/Tofudog/Yeetcode/blob/main/LICENSE" target="_blank">license</a>
+                </li>
+            </p>
+        </ol>
+    </div>
+    <div class="center-container">
+        <br><br><br><br>
+        <h3>Copyright 2025 @Yeetcode</h3>
+        <div class="side-by-side">
+            <a href="./login-page-screen.html"><h3>Back to Login Page</h3></a>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            <h3><u>Privacy Policy</u></h3>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/ChromeExtension/Frontend/login-page-screen.html
+++ b/ChromeExtension/Frontend/login-page-screen.html
@@ -41,9 +41,9 @@
         <br><br><br><br>
         <h3>Copyright 2025 @Yeetcode</h3>
         <div class="side-by-side">
-            <h3><u>Terms of Service</u></h3>
+            <a href="./code-of-conduct.html"><h3>Terms of Service</h3></a>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <h3><u>Terms of Service</u></h3>
+            <h3><u>Privacy Policy</u></h3>
         </div>
     </div>
 


### PR DESCRIPTION
I created the code of conduct page according to how it looked in the Figma design. It contains a general list of rules Yeetcode users must follow while using the platform and the rules about ownership of content. It also contains a link to the license for this repository, found in https://github.com/Tofudog/Yeetcode/blob/main/LICENSE.

This is a pull request to merge into `signup-page` instead of `main` because the former has not been merged into the latter.