### PR TITLE
Implement update and getting elo on backend

### DIFF
--- a/ChromeExtension/Backend/controllers/eloController.js
+++ b/ChromeExtension/Backend/controllers/eloController.js
@@ -1,0 +1,32 @@
+import User from '../models/userModel.js';
+
+const getElo = async (req, res) => {
+    const { yeetcode_username } = req.body;
+    const userObject = await User.findOne({ yeetcode_username: yeetcode_username });
+    // if (!userObject) return res.status(404).json({ message: 'User not found' });
+    const userElo = userObject.elo;
+    console.log(userObject);
+
+    return res.status(200).json({
+        yeetcode_username: yeetcode_username,
+        elo: userElo
+    });
+}
+
+const updateElo = async (req, res) => {
+    const { yeetcode_username, newElo } = req.body;
+    const userObject = await User.findOne({ yeetcode_username: yeetcode_username });
+    const previousElo = userObject.elo;
+
+    const update = { elo: newElo };
+    const filter = { yeetcode_username: yeetcode_username };
+    const result = await User.updateOne(filter, { $set: update });
+
+    return res.status(200).json({
+        yeetcode_username: yeetcode_username,
+        previous_elo: previousElo,
+        updated_elo: newElo
+    });
+};
+
+export { getElo, updateElo };

--- a/ChromeExtension/Backend/models/userModel.js
+++ b/ChromeExtension/Backend/models/userModel.js
@@ -21,10 +21,10 @@ const UserSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Game'
   }],
-  // elo: {
-  //   type: Float32Array,
-  //   default:
-  // }
+  elo: {
+    type: String,
+    default: "1500"
+  }
 });
 
 const User = mongoose.model('User', UserSchema);

--- a/ChromeExtension/Backend/routes/eloRoutes.js
+++ b/ChromeExtension/Backend/routes/eloRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import {getElo, updateElo} from '../controllers/eloController.js';
+
+const router = express.Router();
+
+// User Routes
+router.post('/getElo', getElo);
+router.post('/updateElo', updateElo);
+
+export default router;

--- a/ChromeExtension/Backend/server.js
+++ b/ChromeExtension/Backend/server.js
@@ -6,6 +6,7 @@ import connectDB from './config/db.js';
 import gameRoutes from './routes/gameRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import authRoutes from './routes/authRoutes.js';
+import eloRoutes from './routes/eloRoutes.js';
 import { fetchRecentSubmissions } from './utils/leetcodeGraphQLQueries.js';
 import { validateUser } from './utils/leetcodeGraphQLQueries.js';
 import { deleteAllUsers } from './controllers/userController.js';
@@ -57,6 +58,7 @@ connectDB();
 app.use('/api/users', userRoutes);
 app.use('/api/games', gameRoutes);
 app.use('/api/auth', authRoutes);
+app.use('/api/elo', eloRoutes);
 
 
 //<!--------------------GraphQL Queries---------------------!>


### PR DESCRIPTION
This pull request allows retrieving and updating a user's elo. Here are the steps to testing it:

1. Move to `ChromeExtension/Backend/`
2. Run the server with `node server.js` (there might be another way to run it)
3. Create a mock user by signing up. This can be on Postman or the UI. On Postman, make a `post` request for **http://localhost:3000/api/** (or wherever the server is running on) and fill in the necessary fields (i.e. `yeetcode_username`, `yeetcode_password`, and `leetcode_username`). Make sure `leetcode_username` is an actual username on Leetcode!
4. To get a user's elo, make a `post` request (not a `get` request!) and fill in the field `yeetcode_username`. You should see the elo as a `String`. If you have not made any elo updates, you should see **"1500"** returned.
5. To update a user's elo, make another `post` request and fill in the fields `yeetcode_username` and `newElo`. You should see the username, previous elo, and updated elo.

Things to complete in future pull requests:

- Change datatype of elo on schema to something integer-based. I might not actually do this, but it would look nicer.
- Implement method(s) for elo updates after each game ends.
- Update elo based off of Alan's methods. I believe the `updateElo()` api can remain, but its input `newElo` will be determined by Alan's methods.